### PR TITLE
Version string compare example in Vue 3 composition

### DIFF
--- a/javascript-vue-composition/package-lock.json
+++ b/javascript-vue-composition/package-lock.json
@@ -8,7 +8,7 @@
       "name": "javascript-vue-composition",
       "version": "0.0.0",
       "dependencies": {
-        "@growthbook/growthbook": "^0.19.1",
+        "@growthbook/growthbook": "^0.27.0",
         "vue": "^3.2.41",
         "vue-router": "^4.1.5"
       },
@@ -95,9 +95,12 @@
       }
     },
     "node_modules/@growthbook/growthbook": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.19.1.tgz",
-      "integrity": "sha512-hDIPlNEf96qgcEOBNwex1Mf9SvIx0+GLKezmJbUneI6aPNJDKv0JO02OGtrHEq2tFp2K0Te9GBCvpTKFaC7wVQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.27.0.tgz",
+      "integrity": "sha512-gt/DWXfgyudY3gXAUjzKm9kMjVfCzfRc8d0nQQiXCP523ow23jThrmBzkRKCN+zxYVxUKcHjP9yjU9EKJqP4Fw==",
+      "dependencies": {
+        "dom-mutator": "^0.5.0"
+      },
       "engines": {
         "node": ">=10"
       }
@@ -899,6 +902,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-mutator": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/dom-mutator/-/dom-mutator-0.5.0.tgz",
+      "integrity": "sha512-bbeX8HWE8JGzraFgbVBX4ws2g3heZFuTtrleQBuN7huy+7n2n7etSuVnot3/1z3jdY2MiwuvoS4Ep1UT2rrGBw==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/error-ex": {
@@ -3687,9 +3698,12 @@
       }
     },
     "@growthbook/growthbook": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.19.1.tgz",
-      "integrity": "sha512-hDIPlNEf96qgcEOBNwex1Mf9SvIx0+GLKezmJbUneI6aPNJDKv0JO02OGtrHEq2tFp2K0Te9GBCvpTKFaC7wVQ=="
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@growthbook/growthbook/-/growthbook-0.27.0.tgz",
+      "integrity": "sha512-gt/DWXfgyudY3gXAUjzKm9kMjVfCzfRc8d0nQQiXCP523ow23jThrmBzkRKCN+zxYVxUKcHjP9yjU9EKJqP4Fw==",
+      "requires": {
+        "dom-mutator": "^0.5.0"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -4276,6 +4290,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-mutator": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/dom-mutator/-/dom-mutator-0.5.0.tgz",
+      "integrity": "sha512-bbeX8HWE8JGzraFgbVBX4ws2g3heZFuTtrleQBuN7huy+7n2n7etSuVnot3/1z3jdY2MiwuvoS4Ep1UT2rrGBw=="
     },
     "error-ex": {
       "version": "1.3.2",

--- a/javascript-vue-composition/package.json
+++ b/javascript-vue-composition/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.19.1",
+    "@growthbook/growthbook": "^0.27.0",
     "vue": "^3.2.41",
     "vue-router": "^4.1.5"
   },

--- a/javascript-vue-composition/src/App.vue
+++ b/javascript-vue-composition/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RouterLink, RouterView } from "vue-router";
 import HelloWorld from "./components/HelloWorld.vue";
+import AppVersion from "./components/AppVersion.vue";
 </script>
 
 <template>
@@ -15,6 +16,10 @@ import HelloWorld from "./components/HelloWorld.vue";
 
     <div class="wrapper">
       <HelloWorld msg="GrowthBook" />
+
+      <div class="app-version-wrapper">
+        <AppVersion />
+      </div>
 
       <nav>
         <RouterLink to="/">Home</RouterLink>
@@ -72,6 +77,10 @@ nav a:first-of-type {
 
   .logo {
     margin: 0 2rem 0 0;
+  }
+
+  .app-version-wrapper {
+    margin: 1rem 0;
   }
 
   header .wrapper {

--- a/javascript-vue-composition/src/components/AppVersion.vue
+++ b/javascript-vue-composition/src/components/AppVersion.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { inject, onMounted, ref } from "vue";
+import { growthBookKey } from "@/utils/growthbook/growthbook";
+
+const growthBookInjectable = inject(growthBookKey);
+
+// if you see "unknown app version," GrowthBook didn't init successfully
+const appVersionName = ref<string>("unknown app version");
+
+onMounted(() => {
+  growthBookInjectable?.init().then((growthBook) => {
+    if (!growthBook) {
+      console.error("GrowthBook failed to initialize");
+      return;
+    }
+
+    // Assign a version string. Supported ones are below. Anything else will return "(unknown)"
+    growthBook.setAttributes({
+      version: "1.1.0", // Albatross for 1.x.x
+      // version: "2.123.456", // Badger for 2.x.x
+      // version: "3.999.55", // Capybara for 3.x.x
+      // version: "99.0.0", // unsupported version results in configured default value "(unknown)"
+    });
+
+    // if you see "??" it isn't in the feature payload
+    const evaluatedAppName = growthBook.getFeatureValue("app_name", "??");
+    appVersionName.value = evaluatedAppName;
+  });
+});
+</script>
+
+<template>
+  <div class="app-version-chip">
+    {{ appVersionName }}
+  </div>
+</template>
+
+<style>
+.app-version-chip {
+  font-size: 0.8rem;
+  font-weight: 700;
+  background: hsla(160, 100%, 37%, 1);
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+}
+</style>


### PR DESCRIPTION
Adds the example for comparing version strings in the Vue 3 composition example. This example names the app after animals.

| Version name | App version |
| ------------ | ----------- |
| Albatross    | 1.x.x       |
| Badger       | 2.x.x       |
| Capybara     | 3.x.x       |


![CleanShot 2023-05-30 at 15 05 04@2x](https://github.com/growthbook/examples/assets/113377031/c31d576f-8a47-4a96-adcc-85132c1c17bc)

<img width="591" alt="image" src="https://github.com/growthbook/examples/assets/113377031/65b7110d-6924-4c8f-a8cb-d21aa34bcbcc">

<img width="593" alt="image" src="https://github.com/growthbook/examples/assets/113377031/dccf6e86-189e-44b3-a32c-bf574784b1a4">



No match:

<img width="580" alt="image" src="https://github.com/growthbook/examples/assets/113377031/d584c47e-7b50-477c-80b5-785a4fa5a15b">


Features JSON can be viewed [here](https://cdn.growthbook.io/api/features/java_NsrWldWd5bxQJZftGsWKl7R2yD2LtAK8C8EUYh9L8).

<img width="420" alt="image" src="https://github.com/growthbook/examples/assets/113377031/cbd5d733-a243-4a7b-846e-bd5e8a99357b">
