### PR TITLE
Add HandlerInterceptor implementation to Java Spring example to DRY up requests

### DIFF
--- a/jvm-spring-web/src/main/java/com/example/demo/AppConfig.java
+++ b/jvm-spring-web/src/main/java/com/example/demo/AppConfig.java
@@ -1,0 +1,18 @@
+package com.example.demo;
+
+import com.example.demo.services.AcmeDonutsFeatureService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AppConfig implements WebMvcConfigurer {
+    @Autowired
+    AcmeDonutsFeatureService acmeDonutsFeatureService;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new GrowthBookSDKInterceptor(acmeDonutsFeatureService));
+    }
+}

--- a/jvm-spring-web/src/main/java/com/example/demo/DemoApplication.java
+++ b/jvm-spring-web/src/main/java/com/example/demo/DemoApplication.java
@@ -25,6 +25,7 @@ public class DemoApplication {
 			System.out.println("French banner (uses features from the GrowthBook API): http://localhost:8080/remote");
 			System.out.println("Features forced by URL: http://localhost:8080/url-feature-force");
 			System.out.println("Features forced by URL (with URL overrides): http://localhost:8080/url-feature-force?gb~meal_overrides_gluten_free=%7B%22meal_type%22%3A%20%22gf%22%2C%20%22dessert%22%3A%20%22French%20Vanilla%20Ice%20Cream%22%7D&gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!");
+			System.out.println("Using an interceptor: http://localhost:8080/interceptors");
 		};
 	}
 }

--- a/jvm-spring-web/src/main/java/com/example/demo/GrowthBookSDKInterceptor.java
+++ b/jvm-spring-web/src/main/java/com/example/demo/GrowthBookSDKInterceptor.java
@@ -1,0 +1,44 @@
+package com.example.demo;
+
+import com.example.demo.models.UserAttributes;
+import com.example.demo.services.AcmeDonutsFeatureService;
+import growthbook.sdk.java.GBContext;
+import growthbook.sdk.java.GrowthBook;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * An example {@link HandlerInterceptor} that allows you to DRY up the requests
+ */
+public class GrowthBookSDKInterceptor implements HandlerInterceptor {
+    AcmeDonutsFeatureService acmeDonutsFeatureService;
+
+    public GrowthBookSDKInterceptor(AcmeDonutsFeatureService acmeDonutsFeatureService) {
+        this.acmeDonutsFeatureService = acmeDonutsFeatureService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        System.out.println("🛰 GrowthBookSDKInterceptor -> preHandle");
+
+        // Pick a mock user type. Employees have donut price 0.00, users from "spain" see Spanish banner text, etc.
+//        String userAttributesJson = UserAttributes.mockUserFromCountry("spain").toJson();
+        String userAttributesJson = UserAttributes.mockUserFromCountry("france").toJson();
+//        String userAttributesJson = UserAttributes.mockRegularUser().toJson();
+//        String userAttributesJson = UserAttributes.mockEmployeeUser().toJson();
+
+        // Init the GBContext with a URL and configure allowUrlOverrides = true
+        GBContext context = GBContext.builder()
+            .featuresJson(acmeDonutsFeatureService.getFeaturesJson())
+            .attributesJson(userAttributesJson)
+            .build();
+
+        GrowthBook growthBook = new GrowthBook(context);
+
+        request.setAttribute("growthbook", growthBook);
+
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+}

--- a/jvm-spring-web/src/main/java/com/example/demo/MainController.java
+++ b/jvm-spring-web/src/main/java/com/example/demo/MainController.java
@@ -25,6 +25,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 @RestController
 public class MainController {
@@ -364,5 +365,27 @@ public class MainController {
         response += String.format("Meal Order Dessert: %s \n\n", mealOrder.getDessert());
 
         return response;
+    }
+
+    /**
+     * Example that uses a {@link org.springframework.web.servlet.HandlerInterceptor}.
+     * See {@link GrowthBookSDKInterceptor} and {@link AppConfig}
+     * @param request The request
+     * @return A hashmap response
+     */
+    @GetMapping("/interceptors")
+    public ResponseEntity<HashMap<String, Object>> usingInterceptors(HttpServletRequest request) {
+        // Get the GrowthBook instance created on the request
+        GrowthBook growthBook = (GrowthBook) request.getAttribute("growthbook");
+
+        // Evaluate features in GrowthBook
+        Float donutPrice = growthBook.getFeatureValue("donut_price", 999f);
+        String bannerText = growthBook.getFeatureValue("banner_text", "(unknown text)");
+
+        HashMap<String, Object> res = new HashMap<>();
+        res.put("donut_price", donutPrice);
+        res.put("banner_text", bannerText);
+
+        return new ResponseEntity<>(res, HttpStatus.OK);
     }
 }

--- a/jvm-spring-web/src/main/java/com/example/demo/models/UserAttributes.java
+++ b/jvm-spring-web/src/main/java/com/example/demo/models/UserAttributes.java
@@ -42,4 +42,39 @@ public class UserAttributes {
     public String toString() {
         return toJson();
     }
+
+    public static UserAttributes mockEmployeeUser() {
+        return new UserAttributes(
+            "user-employee-123456789",
+            "canada",
+            true,
+            true,
+            new ArrayList<>()
+        );
+    }
+
+    public static UserAttributes mockRegularUser() {
+        return new UserAttributes(
+            "user-abc123",
+            "canada",
+            false,
+            false,
+            new ArrayList<>()
+        );
+    }
+
+    /**
+     * to change the value of the feature banner_text
+     * @param country  Supported countries are "france" (French) and "spain" (Spanish)
+     * @return
+     */
+    public static UserAttributes mockUserFromCountry(String country) {
+        return new UserAttributes(
+            "user-abc123",
+            country,
+            false,
+            false,
+            new ArrayList<>()
+        );
+    }
 }


### PR DESCRIPTION
The following approach uses an approach similar to Go Chi and Node.js Express middleware, where you can create a new `GrowthBook` instance in the middleware, and reference it in all your request handlers. See the handler at `"/interceptors"` for implementation details.