### PR TITLE
Sandbox: sdk-version sync receiver

### DIFF
--- a/.github/workflows/sync-sdk-version.yml
+++ b/.github/workflows/sync-sdk-version.yml
@@ -1,0 +1,94 @@
+name: Sync SDK version
+
+# Receiver for SDK release notifications. An SDK repo fires a repository_dispatch
+# (event_type: update-sdk-version) after it publishes; this workflow prepends the
+# new version to packages/shared/src/sdk-versioning/sdk-versions/<sdk>.json and
+# opens a PR. Generic over `sdk`, so one file serves every SDK.
+#
+# This copy lives in growthbook/examples as a sandbox. The production copy is the
+# same file in growthbook/growthbook. Trigger it two ways:
+#   - workflow_dispatch: run by hand with sdk + version inputs.
+#   - repository_dispatch: from an SDK repo's release (or a manual `gh api ...`).
+
+on:
+  repository_dispatch:
+    types: [update-sdk-version]
+  workflow_dispatch:
+    inputs:
+      sdk:
+        required: true
+        description: "SDK key, e.g. rust"
+      version:
+        required: true
+        description: "Released version, e.g. 0.2.1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepend version (idempotent; no-op if not newer)
+        id: bump
+        env:
+          SDK: ${{ github.event.client_payload.sdk || inputs.sdk }}
+          VERSION: ${{ github.event.client_payload.version || inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Version '$VERSION' is not x.y.z"; exit 1
+          fi
+          # SDK key -> filename (a few keys don't map 1:1 to their file).
+          case "$SDK" in
+            android)  F=kotlin ;;
+            ios)      F=swift ;;
+            nocode-*) F=nocode ;;
+            *)        F="$SDK" ;;
+          esac
+          FILE="packages/shared/src/sdk-versioning/sdk-versions/$F.json"
+          if [ ! -f "$FILE" ]; then
+            echo "No sdk-versions file for '$SDK' ($FILE)"; exit 1
+          fi
+          CURRENT=$(jq -r '.versions[0].version' "$FILE")
+          # No-op if the version is already listed, or is not strictly newer than
+          # the current top entry (sort -V is version-aware: 0.2.10 > 0.2.9).
+          if jq -e --arg v "$VERSION" '.versions[] | select(.version == $v)' "$FILE" >/dev/null \
+             || [ "$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -1)" != "$VERSION" ]; then
+            echo "rust.json already up to date ($VERSION <= $CURRENT); nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Prepend a version-only entry. Capabilities (if any) are added by the
+          # reviewer on the PR — they can't be derived from a version number.
+          jq --arg v "$VERSION" '.versions |= ([{version: $v}] + .)' "$FILE" > "$FILE.tmp"
+          mv "$FILE.tmp" "$FILE"
+          npx --yes prettier@3 --write "$FILE"
+          {
+            echo "changed=true"
+            echo "sdk=$SDK"
+            echo "version=$VERSION"
+            echo "file=$FILE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Prepended $VERSION to $FILE (was $CURRENT)."
+
+      - name: Open PR
+        if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: sdk-version/${{ steps.bump.outputs.sdk }}-${{ steps.bump.outputs.version }}
+          commit-message: "chore(sdk-versions): ${{ steps.bump.outputs.sdk }} ${{ steps.bump.outputs.version }}"
+          title: "chore(sdk-versions): ${{ steps.bump.outputs.sdk }} ${{ steps.bump.outputs.version }}"
+          labels: sdk-versions, automated
+          body: |
+            Automated from a `${{ steps.bump.outputs.sdk }}` release. Prepends a version-only
+            entry to `${{ steps.bump.outputs.file }}`.
+
+            - [ ] If this release introduced a **gated capability**, add a `"capabilities": [...]`
+              array to the new entry before merging (see the SDK CHANGELOG and the valid values in
+              `packages/shared/src/sdk-versioning/types.ts`). Most releases are version-only — just merge.
+            - [ ] After merge, regenerate SDK docs if capabilities changed:
+              `pnpm --filter shared gen-sdk-resources-for-docs && pnpm --filter shared generate-sdk-report`.

--- a/.github/workflows/sync-sdk-version.yml
+++ b/.github/workflows/sync-sdk-version.yml
@@ -39,6 +39,11 @@ jobs:
           VERSION: ${{ github.event.client_payload.version || inputs.version }}
         run: |
           set -euo pipefail
+          # Validate untrusted dispatch inputs: sdk becomes a filename, so keep
+          # it to a strict slug (no path traversal); version must be plain x.y.z.
+          if ! echo "$SDK" | grep -qE '^[a-z0-9-]+$'; then
+            echo "SDK '$SDK' is not a valid slug"; exit 1
+          fi
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Version '$VERSION' is not x.y.z"; exit 1
           fi

--- a/packages/shared/src/sdk-versioning/sdk-versions/rust.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/rust.json
@@ -1,0 +1,32 @@
+{
+  "versions": [
+    {
+      "version": "0.1.1",
+      "capabilities": ["caseInsensitiveRegex", "caseInsensitiveMembership"]
+    },
+    {
+      "version": "0.1.0",
+      "capabilities": ["stickyBucketing"]
+    },
+    {
+      "version": "0.0.4"
+    },
+    {
+      "version": "0.0.3"
+    },
+    {
+      "version": "0.0.2"
+    },
+    {
+      "version": "0.0.1",
+      "capabilities": [
+        "encryption",
+        "looseUnmarshalling",
+        "namespacesV2",
+        "prerequisites",
+        "semverTargeting",
+        "bucketingV2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Sandbox to prove out the automated `sdk-versions` update flow end-to-end **before** it touches the main `growthbook` app.

This is the receiver half of "SDK release → auto-open a version-bump PR in the main app." The sender half lives in each SDK repo (for Rust: the `notify-main-app` job in `growthbook-rust`'s `release-please.yml`).

## What's included
- **`.github/workflows/sync-sdk-version.yml`** — the generic receiver. Triggers on `repository_dispatch` (`event_type: update-sdk-version`) from an SDK release, or manually via `workflow_dispatch`. It prepends a version-only entry to the SDK's JSON with inline `jq` (no build step), formats with `prettier`, and opens a PR. Idempotent: no-ops if the version is already listed or not strictly newer (`sort -V`, so `0.2.10 > 0.2.9`). Keyed on `sdk`, so one file serves every SDK.
- **`packages/shared/src/sdk-versioning/sdk-versions/rust.json`** — a mirror of the main app's file so the receiver has something to edit here.

## How to test
1. **Receiver alone** — Actions → *Sync SDK version* → *Run workflow* with `sdk=rust, version=0.2.1` → expect a PR prepending `{"version":"0.2.1"}`. Re-run with `0.1.1` → expect **no PR** (no-op).
2. **Dispatch link** — fire a dispatch by hand:
   ```
   gh api repos/growthbook/examples/dispatches --method POST \
     --field event_type=update-sdk-version \
     --field client_payload='{"sdk":"rust","version":"9.9.9"}'
   ```
   → expect a `sdk-version/rust-9.9.9` PR.

## Prerequisite
Enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** in this repo, or the *Open PR* step can't create the PR.

## Not included / out of scope
- Auto-deriving `capabilities` (can't be inferred from a version — left to PR review).
- Doc codegen inside the bot (post-merge checklist item).
- Promotion to `growthbook/growthbook` — happens after this is green; the same workflow file gets copied there and the Rust sender's `SDK_VERSION_TARGET_REPO` var flips to the main app.