### PR TITLE
Sandbox: /capabilities ChatOps harness (stubbed)

### DIFF
--- a/.github/scripts/apply-sdk-capabilities.sh
+++ b/.github/scripts/apply-sdk-capabilities.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Validate a comma-separated capability list against the SDKCapability union in
+# packages/shared/src/sdk-versioning/types.ts and set it on a specific version
+# entry in that SDK's sdk-versions JSON.
+#
+# Usage: apply-sdk-capabilities.sh <repo_root> <sdk> <version> <capabilities_csv>
+#
+# Exit codes:
+#   0  capabilities applied (edited the JSON)
+#   2  empty capability list -> nothing to do (version-only)
+#   3  one or more capabilities are not in types.ts (no changes made)
+#   1  usage / structural error
+#
+# On success (0) and no-op (2) it prints "applied=<csv>" so the caller can echo
+# it back. On rejection (3) it prints "invalid=<csv>".
+set -euo pipefail
+
+ROOT="${1:?repo_root}"
+SDK="${2:?sdk}"
+VERSION="${3:?version}"
+CSV="${4-}"
+
+TYPES="$ROOT/packages/shared/src/sdk-versioning/types.ts"
+[ -f "$TYPES" ] || { echo "types.ts not found at $TYPES" >&2; exit 1; }
+
+# SDK key -> filename (a few keys don't map 1:1 to their file).
+case "$SDK" in
+  android)  FILE_STEM=kotlin ;;
+  ios)      FILE_STEM=swift ;;
+  nocode-*) FILE_STEM=nocode ;;
+  *)        FILE_STEM="$SDK" ;;
+esac
+FILE="$ROOT/packages/shared/src/sdk-versioning/sdk-versions/$FILE_STEM.json"
+[ -f "$FILE" ] || { echo "no sdk-versions file for '$SDK' ($FILE)" >&2; exit 1; }
+
+# The version entry the PR added must exist.
+if ! jq -e --arg v "$VERSION" '.versions[] | select(.version == $v)' "$FILE" >/dev/null; then
+  echo "version $VERSION not present in $FILE" >&2; exit 1
+fi
+
+# The single source of truth for valid capabilities: the SDKCapability union.
+VALID="$(sed -n '/export type SDKCapability =/,/;/p' "$TYPES" | grep -oE '"[A-Za-z0-9]+"' | tr -d '"')"
+
+# Parse + trim the CSV. Empty -> no-op (version-only).
+CLEANED="$(echo "$CSV" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true)"
+if [ -z "$CLEANED" ]; then
+  echo "applied="
+  exit 2
+fi
+
+invalid=""
+while IFS= read -r cap; do
+  grep -qx "$cap" <<< "$VALID" || invalid="${invalid:+$invalid, }$cap"
+done <<< "$CLEANED"
+
+if [ -n "$invalid" ]; then
+  echo "invalid=$invalid"
+  exit 3
+fi
+
+# Build a JSON array from the validated, de-duplicated (order-preserving) list.
+CAPS_JSON="$(echo "$CLEANED" | awk '!seen[$0]++' | jq -R . | jq -sc .)"
+
+# Set capabilities on exactly the target version entry. `(...) |= ` mutates in place.
+tmp="$(mktemp)"
+jq --arg v "$VERSION" --argjson caps "$CAPS_JSON" \
+  '(.versions[] | select(.version == $v)).capabilities = $caps' "$FILE" > "$tmp"
+mv "$tmp" "$FILE"
+
+echo "applied=$(echo "$CLEANED" | awk '!seen[$0]++' | paste -sd ',' -)"
+exit 0

--- a/.github/scripts/gen-sdk-info-stub.mjs
+++ b/.github/scripts/gen-sdk-info-stub.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// STUB stand-in for the main app's pre-commit `gen-sdk-resources-for-docs`.
+//
+// In growthbook/growthbook, a pre-commit hook regenerates docs/src/data/SDKInfo.ts
+// whenever anything under shared/src/sdk-versioning changes. That generator needs
+// the full shared + sdk-js build, which we deliberately do NOT pull into this
+// sandbox. This stub reproduces the essential behaviour — deriving a docs artifact
+// from the sdk-versions JSON — so we can prove the "edit JSON -> regenerate derived
+// file -> commit both" loop end to end without the main-app dependency graph.
+//
+// It reads every sdk-versions/*.json and writes docs/src/data/SDKInfo.generated.json
+// mapping each SDK to its latest version and the capabilities it declares. Both a
+// version bump and a capability edit change this file, exactly like SDKInfo.ts.
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const dir = path.join(root, "packages/shared/src/sdk-versioning/sdk-versions");
+const out = path.join(root, "docs/src/data/SDKInfo.generated.json");
+
+const info = {};
+for (const file of readdirSync(dir).filter((f) => f.endsWith(".json")).sort()) {
+  const sdk = file.replace(/\.json$/, "");
+  const data = JSON.parse(readFileSync(path.join(dir, file), "utf8"));
+  const versions = data.versions || [];
+  const capabilities = [];
+  for (const v of versions) {
+    for (const c of v.capabilities || []) {
+      if (!capabilities.includes(c)) capabilities.push(c);
+    }
+  }
+  info[sdk] = { latest: versions[0]?.version || "0.0.0", capabilities };
+}
+
+writeFileSync(out, JSON.stringify(info, null, 2) + "\n");
+console.log(`Wrote ${out} for ${Object.keys(info).length} SDK(s).`);

--- a/.github/workflows/sdk-version-capabilities.yml
+++ b/.github/workflows/sdk-version-capabilities.yml
@@ -1,0 +1,109 @@
+name: SDK version capabilities
+
+# SANDBOX copy of the main app's capabilities ChatOps. On a PR whose branch is
+# `sdk-version/<sdk>-<x.y.z>`, comment:
+#
+#     /capabilities streaming, redirects
+#
+# It validates each token against the SDKCapability union in types.ts, sets them
+# on that version entry in the SDK JSON, regenerates the derived docs artifact,
+# and commits back to the PR branch. Empty `/capabilities` -> version-only.
+# Unknown tokens are rejected with a comment and nothing changes.
+#
+# Differences from the main app (deliberately stubbed to detangle from its deps):
+#   - Doc regen calls .github/scripts/gen-sdk-info-stub.mjs instead of the real
+#     `pnpm --filter shared gen-sdk-resources-for-docs` (which needs the full
+#     shared + sdk-js build). In the main app that step is the existing
+#     pre-commit hook; here we invoke the stub explicitly.
+#
+# issue_comment workflows only run from the copy on the default branch, so this
+# must be on `main` to fire.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  capabilities:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/capabilities') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Check out the PR branch and parse sdk/version
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh pr checkout "$PR"
+          head="$(git rev-parse --abbrev-ref HEAD)"
+          if [[ ! "$head" =~ ^sdk-version/(.+)-([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "PR branch '$head' is not sdk-version/<sdk>-<x.y.z>; ignoring."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          {
+            echo "sdk=${BASH_REMATCH[1]}"
+            echo "version=${BASH_REMATCH[2]}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate + apply capabilities to the JSON
+        if: ${{ steps.pr.outputs.skip != 'true' }}
+        id: apply
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+          SDK: ${{ steps.pr.outputs.sdk }}
+          VERSION: ${{ steps.pr.outputs.version }}
+        run: |
+          set -uo pipefail
+          CSV="$(printf '%s\n' "$COMMENT" | head -n1 | sed -E 's#^/capabilities##')"
+          out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")"; code=$?
+          echo "$out"
+          echo "result=$out" >> "$GITHUB_OUTPUT"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Reject unknown capabilities
+        if: ${{ steps.apply.outputs.code == '3' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          RESULT: ${{ steps.apply.outputs.result }}
+        run: |
+          gh pr comment "$PR" --body "❌ Unknown capabilities: **${RESULT#invalid=}**. Valid values come from \`packages/shared/src/sdk-versioning/types.ts\`. No changes made."
+          exit 1
+
+      - name: Acknowledge version-only
+        if: ${{ steps.apply.outputs.code == '2' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: gh pr comment "$PR" --body "No capabilities given — recording this release as version-only. Ready to merge."
+
+      - name: Regenerate derived docs, commit, and comment
+        if: ${{ steps.apply.outputs.code == '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          SDK: ${{ steps.pr.outputs.sdk }}
+          VERSION: ${{ steps.pr.outputs.version }}
+          RESULT: ${{ steps.apply.outputs.result }}
+        run: |
+          set -euo pipefail
+          caps="${RESULT#applied=}"
+          npx --yes prettier@3.6.2 --write "packages/shared/src/sdk-versioning/sdk-versions/$SDK.json"
+          node .github/scripts/gen-sdk-info-stub.mjs
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/shared/src/sdk-versioning docs/src/data/SDKInfo.generated.json
+          git commit -m "chore(sdk-versions): $SDK $VERSION capabilities [$caps]"
+          git push
+          gh pr comment "$PR" --body "✅ Set capabilities **[$caps]** on \`$SDK\` $VERSION and regenerated the derived docs artifact."

--- a/.github/workflows/sync-sdk-version.yml
+++ b/.github/workflows/sync-sdk-version.yml
@@ -80,6 +80,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Prepended $VERSION to $FILE (was $CURRENT)."
 
+      # Mirror the main app's pre-commit hook, which regenerates the docs artifact
+      # on any sdk-versioning change. (Here: the stub generator; in the main app:
+      # gen-sdk-resources-for-docs regenerating SDKInfo.ts.)
+      - name: Regenerate derived docs
+        if: steps.bump.outputs.changed == 'true'
+        run: node .github/scripts/gen-sdk-info-stub.mjs
+
       - name: Open PR
         if: steps.bump.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
@@ -90,10 +97,13 @@ jobs:
           labels: sdk-versions, automated
           body: |
             Automated from a `${{ steps.bump.outputs.sdk }}` release. Prepends a version-only
-            entry to `${{ steps.bump.outputs.file }}`.
+            entry to `${{ steps.bump.outputs.file }}` and regenerates the derived docs artifact.
 
-            - [ ] If this release introduced a **gated capability**, add a `"capabilities": [...]`
-              array to the new entry before merging (see the SDK CHANGELOG and the valid values in
-              `packages/shared/src/sdk-versioning/types.ts`). Most releases are version-only — just merge.
-            - [ ] After merge, regenerate SDK docs if capabilities changed:
-              `pnpm --filter shared gen-sdk-resources-for-docs && pnpm --filter shared generate-sdk-report`.
+            **If this release introduced a gated capability**, comment on this PR:
+
+            ```
+            /capabilities streaming, redirects
+            ```
+
+            The bot validates each value against `types.ts`, sets them on the new version
+            entry, regenerates docs, and commits back. No capability? Just merge (version-only).

--- a/docs/src/data/SDKInfo.generated.json
+++ b/docs/src/data/SDKInfo.generated.json
@@ -1,0 +1,16 @@
+{
+  "rust": {
+    "latest": "0.2.1",
+    "capabilities": [
+      "caseInsensitiveRegex",
+      "caseInsensitiveMembership",
+      "stickyBucketing",
+      "encryption",
+      "looseUnmarshalling",
+      "namespacesV2",
+      "prerequisites",
+      "semverTargeting",
+      "bucketingV2"
+    ]
+  }
+}

--- a/packages/shared/src/sdk-versioning/types.ts
+++ b/packages/shared/src/sdk-versioning/types.ts
@@ -1,0 +1,21 @@
+// Copied from growthbook/growthbook packages/shared/src/sdk-versioning/types.ts
+// so the capabilities validator has the same single source of truth here in the
+// examples sandbox. Keep the SDKCapability union in sync with the main app.
+export type SDKCapability =
+  | "looseUnmarshalling"
+  | "encryption"
+  | "streaming"
+  | "bucketingV2"
+  | "visualEditor"
+  | "semverTargeting"
+  | "visualEditorJS"
+  | "remoteEval"
+  | "visualEditorDragDrop"
+  | "stickyBucketing"
+  | "redirects"
+  | "prerequisites"
+  | "savedGroupReferences"
+  | "caseInsensitiveRegex"
+  | "caseInsensitiveMembership"
+  | "namespacesV2"
+  | "contextualBandits";


### PR DESCRIPTION
Self-contained harness to test the `/capabilities` flow end-to-end in examples, detangled from main-app build deps.

- `packages/shared/src/sdk-versioning/types.ts` (copied) — capability allowlist source.
- `.github/scripts/gen-sdk-info-stub.mjs` — dependency-free stand-in for the main app's pre-commit `gen-sdk-resources-for-docs` (reads sdk-versions JSON → writes `docs/src/data/SDKInfo.generated.json`).
- `.github/scripts/apply-sdk-capabilities.sh` — validate tokens against types.ts + set on the version entry (exit 0 applied / 2 version-only / 3 unknown).
- `sdk-version-capabilities.yml` — the `/capabilities` comment-command.
- `sync-sdk-version.yml` — receiver now regenerates the derived docs too (mirrors the pre-commit hook).

**Merge to main** so `issue_comment` can fire, then I'll run the end-to-end test (valid caps, unknown caps, version-only).