### PR TITLE
Fix: capture /capabilities apply exit code under bash -e

### DIFF
--- a/.github/workflows/sdk-version-capabilities.yml
+++ b/.github/workflows/sdk-version-capabilities.yml
@@ -65,11 +65,15 @@ jobs:
         run: |
           set -uo pipefail
           CSV="$(printf '%s\n' "$COMMENT" | head -n1 | sed -E 's#^/capabilities##')"
-          out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")"; code=$?
+          # GitHub runs steps with `bash -e`; the apply script exits 2/3 by design,
+          # so guard with `|| code=$?` to capture the code instead of aborting.
+          code=0
+          out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")" || code=$?
           echo "$out"
-          echo "result=$out" >> "$GITHUB_OUTPUT"
-          echo "code=$code" >> "$GITHUB_OUTPUT"
-          exit 0
+          {
+            echo "result=$out"
+            echo "code=$code"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Reject unknown capabilities
         if: ${{ steps.apply.outputs.code == '3' }}


### PR DESCRIPTION
The apply step ran under GitHub's default `bash -e`, so the apply script's intentional non-zero exits (2 = version-only, 3 = unknown caps) aborted the step before it could branch on the code. Guard the call with `|| code=$?`.

Verified locally under `bash -e`: empty → code 2, unknown → code 3 (no mutation), valid → code 0 (sets capabilities), step exit 0 in all cases.

Merge to main so the next /capabilities test picks it up.